### PR TITLE
fix:小程序码生成,微信接口字段增加

### DIFF
--- a/qr_code.go
+++ b/qr_code.go
@@ -22,11 +22,12 @@ type Color struct {
 
 // QRCode 小程序码参数
 type QRCode struct {
-	Path      string `json:"path"`
-	Width     int    `json:"width,omitempty"`
-	AutoColor bool   `json:"auto_color,omitempty"`
-	LineColor Color  `json:"line_color,omitempty"`
-	IsHyaline bool   `json:"is_hyaline,omitempty"`
+	Path       string `json:"path"`
+	EnvVersion string `json:"env_version,omitempty"` //要打开的小程序版本
+	Width      int    `json:"width,omitempty"`
+	AutoColor  bool   `json:"auto_color,omitempty"`
+	LineColor  Color  `json:"line_color,omitempty"`
+	IsHyaline  bool   `json:"is_hyaline,omitempty"`
 }
 
 // Get 获取小程序码
@@ -44,12 +45,14 @@ func (code *QRCode) get(api, token string) (*http.Response, *CommonError, error)
 
 // UnlimitedQRCode 小程序码参数
 type UnlimitedQRCode struct {
-	Scene     string `json:"scene"`
-	Page      string `json:"page,omitempty"`
-	Width     int    `json:"width,omitempty"`
-	AutoColor bool   `json:"auto_color,omitempty"`
-	LineColor Color  `json:"line_color,omitempty"`
-	IsHyaline bool   `json:"is_hyaline,omitempty"`
+	Scene      string `json:"scene"`
+	Page       string `json:"page,omitempty"`
+	CheckPath  bool   `json:"check_path,omitempty"`  //检查 page 是否存在
+	EnvVersion string `json:"env_version,omitempty"` //要打开的小程序版本
+	Width      int    `json:"width,omitempty"`
+	AutoColor  bool   `json:"auto_color,omitempty"`
+	LineColor  Color  `json:"line_color,omitempty"`
+	IsHyaline  bool   `json:"is_hyaline,omitempty"`
 }
 
 // Get 获取小程序码

--- a/qr_code_test.go
+++ b/qr_code_test.go
@@ -93,11 +93,12 @@ func TestGetQRCode(t *testing.T) {
 		}
 
 		params := struct {
-			Path      string `json:"path"`
-			Width     int    `json:"width,omitempty"`
-			AutoColor bool   `json:"auto_color,omitempty"`
-			LineColor Color  `json:"line_color,omitempty"`
-			IsHyaline bool   `json:"is_hyaline,omitempty"`
+			Path       string `json:"path"`
+			EnvVersion string `json:"env_version,omitempty"`
+			Width      int    `json:"width,omitempty"`
+			AutoColor  bool   `json:"auto_color,omitempty"`
+			LineColor  Color  `json:"line_color,omitempty"`
+			IsHyaline  bool   `json:"is_hyaline,omitempty"`
 		}{}
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
 			t.Fatal(err)
@@ -161,12 +162,14 @@ func TestGetUnlimitedQRCode(t *testing.T) {
 		}
 
 		params := struct {
-			Scene     string `json:"scene"`
-			Page      string `json:"page,omitempty"`
-			Width     int    `json:"width,omitempty"`
-			AutoColor bool   `json:"auto_color,omitempty"`
-			LineColor Color  `json:"line_color,omitempty"`
-			IsHyaline bool   `json:"is_hyaline,omitempty"`
+			Scene      string `json:"scene"`
+			Page       string `json:"page,omitempty"`
+			CheckPath  bool   `json:"check_path,omitempty"`  //检查 page 是否存在
+			EnvVersion string `json:"env_version,omitempty"` //要打开的小程序版本
+			Width      int    `json:"width,omitempty"`
+			AutoColor  bool   `json:"auto_color,omitempty"`
+			LineColor  Color  `json:"line_color,omitempty"`
+			IsHyaline  bool   `json:"is_hyaline,omitempty"`
 		}{}
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
小程序码生成接口wxacode.get和wxacode.getUnlimited请求参数有更新，请对V2版本进行补丁更新
[wxacode.get](https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/qr-code/wxacode.get.html)
新增env_version
[wxacode.getUnlimited](https://developers.weixin.qq.com/miniprogram/dev/api-backend/open-api/qr-code/wxacode.getUnlimited.html)
新增check_path,env_version