### PR TITLE
fix: SubscribeMsgSentEvent.List.ErrorStatus should be a string

### DIFF
--- a/server/types.go
+++ b/server/types.go
@@ -704,7 +704,7 @@ type SubscribeMsgSentEvent struct {
 			// 推送结果状态码（0表示成功）
 			ErrorCode int `json:"ErrorCode" xml:"ErrorCode"`
 			// 推送结果状态码对应的含义
-			ErrorStatus int `json:"ErrorStatus" xml:"ErrorStatus"`
+			ErrorStatus string `json:"ErrorStatus" xml:"ErrorStatus"`
 		} `json:"List" xml:"List"`
 	} `json:"SubscribeMsgSentEvent" xml:"SubscribeMsgSentEvent"`
 }


### PR DESCRIPTION
订阅消息 SubscribeMsgSentEvent 事件里面的 ErrorStatus 是一个字符串而不是 int


https://developers.weixin.qq.com/doc/offiaccount/Subscription_Messages/api.html#send%E5%8F%91%E9%80%81%E8%AE%A2%E9%98%85%E9%80%9A%E7%9F%A5:~:text=List%3E%0A%20%20%20%20%3C%2FSubscribeMsgChangeEvent%3E%0A%3C%2Fxml%3E-,%E5%8F%91%E9%80%81%E8%AE%A2%E9%98%85%E9%80%9A%E7%9F%A5,%E6%8E%A5%E5%8F%A3%E5%8F%91%E9%80%81%E9%80%9A%E7%9F%A5,-%E5%8F%82%E6%95%B0


![image](https://github.com/user-attachments/assets/be416a35-e588-4f7c-bcf1-9be5b202b4bb)
